### PR TITLE
Feature/#456 scale of bar graph グラフの大きさ及び目盛について調整

### DIFF
--- a/resources/components/BarGraph.vue
+++ b/resources/components/BarGraph.vue
@@ -22,26 +22,22 @@
 
   // 最大値の大きさごとにグラフの最大の高さを指定する関数
   const getMaxValueResponse = (arr) => {
+    // 境界値
+    const thresholds = [10, 25, 50, 100];
     // 受け取った配列から最大値を取得する
     const maxValue = Math.max(...arr);
-    // 配列の最大値ごとにグラフの最大高さを返す．
-    if (maxValue < 10) {
-        return 10;
-    } else if (maxValue >= 10 && maxValue < 25) {
-        return 25;
-    } else if (maxValue >= 25 && maxValue < 50) {
-        return 50;
-    } else if(maxValue >= 50 && maxValue < 100){
-        return 100;
-    }else {
-      return maxValue
+    for (let threshold of thresholds) {
+      if (maxValue < threshold) {
+        return threshold;
+      }
     }
-}
+    return maxValue;
+  };
 
   const keysAndValues = extractKeyAndValue(props.barGraphData);
   const labels = keysAndValues.keys;
   const data = keysAndValues.values;
-  const maxValue = getMaxValueResponse(data)
+  const maxValue = getMaxValueResponse(data);
 
   // Chart.js
   const loadChartJS = () => {
@@ -95,8 +91,8 @@
             beginAtZero: true,
             min: 0,
             max: maxValue, // グラフの最大高
-            ticks : {
-              stepSize : 10
+            ticks: {
+              stepSize: 10
             }
           }
         },

--- a/resources/components/BarGraph.vue
+++ b/resources/components/BarGraph.vue
@@ -20,9 +20,28 @@
     };
   };
 
+  // 最大値の大きさごとにグラフの最大の高さを指定する関数
+  const getMaxValueResponse = (arr) => {
+    // 受け取った配列から最大値を取得する
+    const maxValue = Math.max(...arr);
+    // 配列の最大値ごとにグラフの最大高さを返す．
+    if (maxValue < 10) {
+        return 10;
+    } else if (maxValue >= 10 && maxValue < 25) {
+        return 25;
+    } else if (maxValue >= 25 && maxValue < 50) {
+        return 50;
+    } else if(maxValue >= 50 && maxValue < 100){
+        return 100;
+    }else {
+      return maxValue
+    }
+}
+
   const keysAndValues = extractKeyAndValue(props.barGraphData);
   const labels = keysAndValues.keys;
   const data = keysAndValues.values;
+  const maxValue = getMaxValueResponse(data)
 
   // Chart.js
   const loadChartJS = () => {
@@ -75,8 +94,10 @@
           y: {
             beginAtZero: true,
             min: 0,
-            //   max: 100, // Adjust the max value as needed
-            stepSize: 10 // Adjust the step size as needed
+            max: maxValue, // グラフの最大高
+            ticks : {
+              stepSize : 10
+            }
           }
         },
         maintainAspectRatio: false,

--- a/resources/components/BarGraph.vue
+++ b/resources/components/BarGraph.vue
@@ -92,7 +92,7 @@
             min: 0,
             max: maxValue, // グラフの最大高
             ticks: {
-              stepSize: 10
+              stepSize: 2
             }
           }
         },

--- a/resources/components/BarGraph.vue
+++ b/resources/components/BarGraph.vue
@@ -1,8 +1,6 @@
 <script setup>
   import { ref, onMounted } from "vue";
 
-  // const props = defineProps(["barGraphData"]);
-  // const barGraphData = [20, 30, 40, 50, 60]
   const props = defineProps(["barGraphData", "chartTitle"]);
 
   const extractKeyAndValue = (jsonData) => {

--- a/resources/components/ClassDetail.vue
+++ b/resources/components/ClassDetail.vue
@@ -84,7 +84,7 @@
                   </v-col>
                 </v-row>
                 <v-row>
-                  <v-col>
+                  <v-col class="d-flex justify-center">
                     <v-window v-model="toggle">
                       <v-window-item value="btn-1">
                         <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>

--- a/resources/components/RadarChart.vue
+++ b/resources/components/RadarChart.vue
@@ -67,6 +67,6 @@
 
 <template>
   <div>
-    <canvas ref="radarChart" width="350" height="350"></canvas>
+    <canvas ref="radarChart" width="600" height="350"></canvas>
   </div>
 </template>


### PR DESCRIPTION
## 概要 ✨

<!-- このプルリクエストで何をしたのか、変更の目的や背景を簡潔に説明してください -->
#456 
http://localhost:9001/class/1/detail

## 変更点 👨‍💻

<!-- このプルリクエストで行った変更点を具体的に説明してください -->
- 棒グラフの横幅が広くなりすぎていたのでレーダーチャートと同じくらいにした
- 棒グラフのy軸のメモリについて指定されていなかったためカスタマイズして指定
![image](https://github.com/YamamotoNagito/l10dev/assets/134689144/2d70b5c3-e664-4538-86f9-f2ff37d2fe33)


## テスト 🧪

<!-- このプルリクエストで行った変更をテストする方法や、テスト結果があれば記載してください -->

- [ ] 棒グラフの大きさが不自然でないか
- [ ] 棒グラフの縦軸の目盛はこれで良いか
