### PR TITLE
Feature/#490 size of radar chart

### DIFF
--- a/resources/components/ClassDetail.vue
+++ b/resources/components/ClassDetail.vue
@@ -84,15 +84,11 @@
                   </v-col>
                 </v-row>
                 <v-row>
-                  <v-col class="d-flex justify-center">
+                  <v-col class="d-flex justify-center" cols="12">
                     <v-window v-model="toggle">
-                      <v-row>
-                        <v-col cols="12">
-                          <v-window-item value="btn-1">
-                            <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>
-                          </v-window-item>
-                        </v-col>
-                      </v-row>
+                      <v-window-item value="btn-1">
+                        <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>
+                      </v-window-item>
                       <v-window-item value="btn-2">
                         <BarGraph
                           :bar-graph-data="classDetailData?.classBarGraphData?.grades"

--- a/resources/components/ClassDetail.vue
+++ b/resources/components/ClassDetail.vue
@@ -86,9 +86,13 @@
                 <v-row>
                   <v-col class="d-flex justify-center">
                     <v-window v-model="toggle">
-                      <v-window-item value="btn-1">
-                        <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>
-                      </v-window-item>
+                      <v-row>
+                        <v-col cols="12">
+                          <v-window-item value="btn-1">
+                            <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>
+                          </v-window-item>
+                        </v-col>
+                      </v-row>
                       <v-window-item value="btn-2">
                         <BarGraph
                           :bar-graph-data="classDetailData?.classBarGraphData?.grades"

--- a/resources/components/ClassDetail.vue
+++ b/resources/components/ClassDetail.vue
@@ -87,7 +87,11 @@
                   <v-col class="d-flex justify-center" cols="12">
                     <v-window v-model="toggle">
                       <v-window-item value="btn-1">
-                        <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart>
+                        <v-row>
+                          <v-col cols="12">
+                            <RadarChart :radar-chart-data="classDetailData?.classRadarChartData"></RadarChart
+                          >
+                          </v-col></v-row>
                       </v-window-item>
                       <v-window-item value="btn-2">
                         <BarGraph

--- a/resources/components/RadarChart.vue
+++ b/resources/components/RadarChart.vue
@@ -67,7 +67,7 @@
 
 <template>
   <div class="wrap-chart">
-    <div class="chart-container d-flex justify-center">
+    <div class="chart-container">
       <canvas ref="radarChart"></canvas>
     </div>
   </div>
@@ -78,5 +78,9 @@
   .wrap-chart {
     width: 100%;
     height: 400px;
+    position: relative;
+    right: 20px
   }
+  
+  
 </style>

--- a/resources/components/RadarChart.vue
+++ b/resources/components/RadarChart.vue
@@ -67,7 +67,7 @@
 
 <template>
   <div class="wrap-chart">
-    <div class="chart-container d-flex justity-center">
+    <div class="chart-container d-flex justify-center">
       <canvas ref="radarChart"></canvas>
     </div>
   </div>

--- a/resources/components/RadarChart.vue
+++ b/resources/components/RadarChart.vue
@@ -66,7 +66,17 @@
 </script>
 
 <template>
-  <div>
-    <canvas ref="radarChart" width="600" height="350"></canvas>
+  <div class="wrap-chart">
+    <div class="chart-container d-flex justity-center">
+      <canvas ref="radarChart"></canvas>
+    </div>
   </div>
 </template>
+
+<style>
+  /* css */
+  .wrap-chart {
+    width: 100%;
+    height: 400px;
+  }
+</style>

--- a/resources/components/RadarChart.vue
+++ b/resources/components/RadarChart.vue
@@ -77,10 +77,5 @@
   /* css */
   .wrap-chart {
     width: 100%;
-    height: 400px;
-    position: relative;
-    right: 20px
-  }
-  
-  
+  } 
 </style>

--- a/resources/components/ReviewSummary.vue
+++ b/resources/components/ReviewSummary.vue
@@ -162,7 +162,7 @@
                     </v-table>
                   </v-col>
                   <v-col cols="12" sm="12" md="12" lg="5">
-                    <RadarChart class="ma-5" :radar-chart-data="radarChartData"></RadarChart>
+                    <div class="radar-chart-in-review"><RadarChart class="ma-5" :radar-chart-data="radarChartData"></RadarChart></div>
                   </v-col>
                 </v-row>
               </details>
@@ -181,5 +181,11 @@
   }
   .review-table {
     background-color: #eceff1;
+  }
+  .radar-chart-in-review{
+    width: 100%;
+    height: 400px;
+    position: relative;
+    right: 20px;
   }
 </style>


### PR DESCRIPTION
## 概要 ✨

<!-- このプルリクエストで何をしたのか、変更の目的や背景を簡潔に説明してください -->
- 授業詳細ページ内のレーダーチャートの大きさを変更
- http://localhost:9001/class/1/detail


## 変更点 👨‍💻

<!-- このプルリクエストで行った変更点を具体的に説明してください -->
- 「基本情報」タブ内の「5段階評価」のレーダーチャートの大きさ・配置（下図）
![image](https://github.com/YamamotoNagito/l10dev/assets/134689144/38eb4ed6-8a37-49a2-9b89-43f6564f5759)

- 個別レビュー内の「評定・カテゴリ別評価」トグル内のレーダーチャートの大きさ・配置（下図）
![image](https://github.com/YamamotoNagito/l10dev/assets/134689144/7c1bc57b-12e6-435e-a0ff-8020454d883e)


## テスト 🧪

<!-- このプルリクエストで行った変更をテストする方法や、テスト結果があれば記載してください -->

- [ ] 授業詳細情報ページ内のレーダーチャートの大きさ・配置が崩れていないか（特にスマホ幅375px程度で確かめて欲しいです）
